### PR TITLE
fix(worksheets): random sheet name when truncated results in duplicates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -799,7 +799,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -5200,8 +5199,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5222,14 +5220,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5244,20 +5240,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5374,8 +5367,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5387,7 +5379,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5402,7 +5393,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5410,14 +5400,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5436,7 +5424,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5517,8 +5504,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5530,7 +5516,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5616,8 +5601,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5653,7 +5637,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5673,7 +5656,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5717,14 +5699,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/index.js
+++ b/src/index.js
@@ -75,14 +75,29 @@ module.exports = class TypeformExportExcel {
   }
 
   _createSingleWorksheet({questionData}) {
-    const worksheetName = this._getWorksheetName(questionData)
-    const worksheet = this.workbook.addWorksheet(worksheetName, {
-      properties: {
-        tabColor: {
-          argb: this._getWorksheetColor()
+    let worksheetName = this._getWorksheetName(questionData)
+    let worksheet
+    try {
+      worksheet = this.workbook.addWorksheet(worksheetName, {
+        properties: {
+          tabColor: {
+            argb: this._getWorksheetColor()
+          }
         }
+      })
+    } catch (error) {
+      if (error.message.match('Worksheet name already exists')) {
+        worksheetName = `${Date.now()}-${Math.floor(Math.random() * 1000000)}`
+
+        worksheet = this.workbook.addWorksheet(worksheetName, {
+          properties: {
+            tabColor: {
+              argb: this._getWorksheetColor()
+            }
+          }
+        })
       }
-    })
+    }
 
     this._populateWorksheetHeaders(worksheet, questionData)
     this._populateWorksheetMetadata(worksheet, questionData)


### PR DESCRIPTION
## Description

A change that had landed in Exceljs introduced a truncating mechanism when worksheets exceed 31 characters and it breaks when there are duplicates: https://github.com/exceljs/exceljs/commit/c1c89f8bee4c083a3709d28dc106d4b9396a839a

## Types of changes

This PR detects when a duplicate exists and then it uses a random value for the sheet name to cope with it.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
