### PR TITLE
Feat/6 filename with date

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ typeformToExcel
   .createWorkbookFromForm(formId)
   .then(() => {
     return typeformToExcel.writeToFile({
-      filename: 'out.xlsx'
+      filename: 'out.xlsx',
+      isDated: true
     })
   })
   .then(() => {
@@ -82,6 +83,8 @@ The following is supported command line arguments:
 | --apiKey    | 1234         | typeform's api key, for example: `--apiKey 1234`                                  |
 | --formId    | Pdi981       | the relevant form id, usually shows up in the URL, for example: `--formId Pdi981` |
 | --filename  | out.xlsx     | the filename to create and write to, for example: `--filename out.xlsx`           |
+| --dated     |              | (optional) the argument for adding export date to filename, for example: `--dated`|
+
 
 Example:
 

--- a/__tests__/export.test.js
+++ b/__tests__/export.test.js
@@ -45,4 +45,46 @@ describe('E2E Export to Excel', () => {
       fs.unlinkSync(testOutputFilename)
     }
   })
+
+  test('Creating an Excel file with date in filename', async () => {
+    expect.assertions(1)
+
+    const testOutputFilename = 'test-out.xlsx'
+    const expectedTestOutputFilename = 'test-out_2016-06-20--03-08-10.xlsx'
+    const RealDate = Date
+    const mockDate = new Date(2016, 5, 20, 3, 8, 10)
+
+    global.Date = class extends RealDate {
+      constructor() {
+        return new RealDate(mockDate)
+      }
+    }
+
+    Form.prototype.fetchFormResponses = jest.fn(() => mockForm)
+
+    const typeformToExcel = new TypeformExportExcel({
+      credentials: {
+        apiKey: mockApiKey
+      },
+      workbookConfig: {
+        creator: 'Creator',
+        date: new Date()
+      }
+    })
+
+    await typeformToExcel.createWorkbookFromForm(mockForm.id)
+
+    await typeformToExcel.writeToFile({
+      filename: testOutputFilename,
+      isDated: true
+    })
+
+    // eslint-disable-next-line
+    const isFileExist = fs.existsSync(path.resolve(expectedTestOutputFilename))
+    expect(isFileExist).toBeTruthy()
+
+    global.Date = RealDate
+    // eslint-disable-next-line
+    fs.unlinkSync(expectedTestOutputFilename)
+  })
 })

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -11,6 +11,7 @@ const args = arg({
   '--apiKey': String,
   '--formId': String,
   '--filename': String,
+  '--dated': Boolean,
   '--author': String,
   '-v': '--version',
   '-h': '--help',
@@ -24,6 +25,9 @@ const formId = args['--formId'] || process.env.TYPEFORM_FORM_ID || ''
 debug(`parsed formId: ${formId}`)
 
 const fileName = args['--filename'] || 'typeform-export-excel.xlsx'
+debug(`parsed filename: ${fileName}`)
+
+const isDated = args['--dated']
 debug(`parsed filename: ${fileName}`)
 
 if (!apiKey || !formId) {
@@ -44,7 +48,8 @@ typeformToExcel
   .createWorkbookFromForm(formId)
   .then(() => {
     return typeformToExcel.writeToFile({
-      filename: fileName
+      filename: fileName,
+      isDated: isDated
     })
   })
   .then(() => {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "@lirantal/typeform-client": "^1.0.5",
     "arg": "^3.0.0",
     "debug": "^4.1.1",
-    "exceljs": "^1.15.0"
+    "exceljs": "^1.15.0",
+    "moment": "^2.24.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.2.1",

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const Excel = require('exceljs')
 const debug = require('debug')('typeform-export-excel')
 const {Form} = require('@lirantal/typeform-client')
 const {HEADER_NAME, HEADER_WIDTH, HEADER_STYLE, WORKSHEET_COLOR} = require('./constants')
+const utils = require('./utils')
 
 const WORKSHEET_NAME_CHAR_LIMIT = 64
 
@@ -232,13 +233,22 @@ module.exports = class TypeformExportExcel {
     })
   }
 
-  async writeToFile({filename}) {
+  async writeToFile({filename, isDated}) {
     try {
+      const finalFileName = isDated ? this._addDateInFileName(filename, new Date()) : filename
       // eslint-disable-next-line
-      await this.workbook.xlsx.writeFile(filename)
+      await this.workbook.xlsx.writeFile(finalFileName)
     } catch (err) {
       debug(err)
       throw err
     }
+  }
+
+  _addDateInFileName(filename, date) {
+    return utils.insertString(
+      filename,
+      '_' + utils.getFormattedDate(date, 'YYYY-MM-DD--HH-mm-ss'),
+      filename.lastIndexOf('.')
+    )
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,15 @@
+'use strict'
+const moment = require('moment')
+
+const insertString = (string, subString, index) => {
+  return string.slice(0, index) + subString + string.slice(index)
+}
+
+const getFormattedDate = (date, format) => {
+  return moment(date).format(format)
+}
+
+module.exports = {
+  insertString,
+  getFormattedDate
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added ability to insert date in filename to make file unique and not override previous file , also to know date when file was exported.  To use should add param and value : `'isDated: true'` in code  or add argument `'--dated'`  in CLI.
Added test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [+] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

#6 

## Motivation and Context

File names are unique and don't  override each other and export date is known

## How Has This Been Tested?

The been tested with real questionary in typeform and new test 

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [+] I have updated the documentation (if required).
- [+] I have read the **CONTRIBUTING** document.
- [+] I have added tests to cover my changes.
- [+] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
